### PR TITLE
Phase 1a-i: defensive security patches (JWT fail-fast, log redaction, ownership)

### DIFF
--- a/docs/issues-to-file.md
+++ b/docs/issues-to-file.md
@@ -1,15 +1,18 @@
-# Issues to file from the v3.0 → production diagnosis
+# Issues filed from the v3.0 → production diagnosis
 
-This is a **review-and-batch-create** ticket file. Each entry is a draft of a
-GitHub issue. Once the owner approves wording, run the helper at the bottom
-of this file (or open them via `gh issue create` manually) to publish them
-under https://github.com/Do-fei/my-raze/issues with the labels noted.
+> **Status:** ✅ All issues have been published as **#2 through #41** in the
+> repository's issue tracker. This document is preserved as the genesis
+> record (so a clone alone is enough to reproduce the publishing step) and
+> as the canonical wording. **Edit issues on GitHub, not this file.**
 
 Phase labels (`phase-1`..`phase-6`) are added so we can filter by phase. The
 severity labels are: `critical` (blocks Phase 1 / production), `high`,
 `medium`, `low`.
 
-Total: 30 issues. (5 critical, 9 high, 11 medium, 5 low.)
+**Total: 40 issues.** Severity breakdown: 5 critical, 13 high, 17 medium,
+2 low. (The original PR description said "30" — that was an underestimate
+from the diagnosis pass; the actual itemized backlog came out to 40 once
+each finding was scoped to a single owner-actionable ticket.)
 
 ---
 

--- a/server/_core/env.test.ts
+++ b/server/_core/env.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Tests for issue #6: JWT_SECRET fail-fast at boot.
+ *
+ * `env.ts` parses `process.env` at module load. To exercise different
+ * `process.env` shapes we save/restore env, then `vi.resetModules()` and
+ * dynamically import `./env` per test.
+ */
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.resetModules();
+  // Reset to a known-clean baseline. Tests opt-in to specific vars.
+  for (const k of Object.keys(process.env)) {
+    delete process.env[k];
+  }
+  process.env.NODE_ENV = "test";
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) {
+    delete process.env[k];
+  }
+  Object.assign(process.env, ORIGINAL_ENV);
+});
+
+describe("env validation (issue #6)", () => {
+  it("throws when JWT_SECRET is missing", async () => {
+    process.env.DATABASE_URL = "mysql://x";
+    await expect(import("./env")).rejects.toThrow(/JWT_SECRET is required/);
+  });
+
+  it("throws when JWT_SECRET is shorter than 32 characters", async () => {
+    process.env.JWT_SECRET = "too-short";
+    process.env.DATABASE_URL = "mysql://x";
+    await expect(import("./env")).rejects.toThrow(
+      /JWT_SECRET must be at least 32 characters/
+    );
+  });
+
+  it("throws when DATABASE_URL is missing in development", async () => {
+    process.env.JWT_SECRET = "a".repeat(32);
+    process.env.NODE_ENV = "development";
+    await expect(import("./env")).rejects.toThrow(/DATABASE_URL is required/);
+  });
+
+  it("throws when DATABASE_URL is empty string in production", async () => {
+    process.env.JWT_SECRET = "a".repeat(32);
+    process.env.DATABASE_URL = "";
+    process.env.NODE_ENV = "production";
+    await expect(import("./env")).rejects.toThrow(
+      /DATABASE_URL must not be empty/
+    );
+  });
+
+  it("does NOT require DATABASE_URL in test mode (Phase-4 carve-out)", async () => {
+    process.env.JWT_SECRET = "a".repeat(32);
+    process.env.NODE_ENV = "test";
+    // No DATABASE_URL set.
+    const { ENV } = await import("./env");
+    expect(ENV.cookieSecret).toBe("a".repeat(32));
+    expect(ENV.databaseUrl).toBe("");
+    expect(ENV.isTest).toBe(true);
+  });
+
+  it("collects multiple violations into one error", async () => {
+    // Force dev mode so both vars are required, then leave both unset.
+    process.env.NODE_ENV = "development";
+    let captured: Error | undefined;
+    try {
+      await import("./env");
+    } catch (e) {
+      captured = e as Error;
+    }
+    expect(captured).toBeDefined();
+    expect(captured!.message).toMatch(/JWT_SECRET/);
+    expect(captured!.message).toMatch(/DATABASE_URL/);
+  });
+
+  it("loads cleanly when all required vars are valid", async () => {
+    process.env.JWT_SECRET = "x".repeat(64);
+    process.env.DATABASE_URL = "mysql://root:devpass@127.0.0.1:3306/myraze";
+    process.env.NODE_ENV = "development";
+    const { ENV } = await import("./env");
+    expect(ENV.cookieSecret).toBe("x".repeat(64));
+    expect(ENV.databaseUrl).toBe(
+      "mysql://root:devpass@127.0.0.1:3306/myraze"
+    );
+    expect(ENV.isProduction).toBe(false);
+    expect(ENV.isTest).toBe(false);
+  });
+
+  it("flags isProduction correctly", async () => {
+    process.env.JWT_SECRET = "x".repeat(64);
+    process.env.DATABASE_URL = "mysql://x";
+    process.env.NODE_ENV = "production";
+    const { ENV } = await import("./env");
+    expect(ENV.isProduction).toBe(true);
+    expect(ENV.isTest).toBe(false);
+  });
+
+  it("attaches structured `issues` to the thrown error", async () => {
+    let captured: any;
+    try {
+      await import("./env");
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured?.name).toBe("EnvValidationError");
+    expect(Array.isArray(captured?.issues)).toBe(true);
+    expect(captured?.issues.length).toBeGreaterThan(0);
+  });
+});

--- a/server/_core/env.ts
+++ b/server/_core/env.ts
@@ -1,10 +1,81 @@
-export const ENV = {
-  appId: process.env.VITE_APP_ID ?? "",
-  cookieSecret: process.env.JWT_SECRET ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? "",
-  oAuthServerUrl: process.env.OAUTH_SERVER_URL ?? "",
-  ownerOpenId: process.env.OWNER_OPEN_ID ?? "",
-  isProduction: process.env.NODE_ENV === "production",
-  forgeApiUrl: process.env.BUILT_IN_FORGE_API_URL ?? "",
-  forgeApiKey: process.env.BUILT_IN_FORGE_API_KEY ?? "",
-};
+/**
+ * Environment-variable validation. Runs at module load.
+ *
+ * If validation fails the module throws `EnvValidationError` with a multi-line
+ * message describing every problem. The server bootstrap lets the throw
+ * propagate so the process exits before any request is served — see issue #6.
+ *
+ * Tests preload required vars in `vitest.setup.ts` so importing this module
+ * inside the test runner never throws.
+ */
+
+const NODE_ENVS = ["development", "test", "production"] as const;
+type NodeEnv = (typeof NODE_ENVS)[number];
+
+export class EnvValidationError extends Error {
+  readonly issues: string[];
+  constructor(issues: string[]) {
+    super(
+      "Invalid environment configuration:\n" +
+        issues.map(i => `  - ${i}`).join("\n") +
+        "\n\nSee .env.example for the full schema."
+    );
+    this.name = "EnvValidationError";
+    this.issues = issues;
+  }
+}
+
+function loadEnv() {
+  const issues: string[] = [];
+  const env = process.env;
+
+  // --- Required: JWT_SECRET ---
+  if (!env.JWT_SECRET) {
+    issues.push(
+      "JWT_SECRET: JWT_SECRET is required. Generate with `openssl rand -hex 32` and set it in .env."
+    );
+  } else if (env.JWT_SECRET.length < 32) {
+    issues.push(
+      "JWT_SECRET: JWT_SECRET must be at least 32 characters. Generate with `openssl rand -hex 32`."
+    );
+  }
+
+  // --- NODE_ENV must be a known value (or absent → defaults) ---
+  const nodeEnv = (env.NODE_ENV ?? "development") as NodeEnv;
+  if (!NODE_ENVS.includes(nodeEnv)) {
+    issues.push(
+      `NODE_ENV: NODE_ENV must be one of ${NODE_ENVS.join(", ")} (got "${env.NODE_ENV}").`
+    );
+  }
+
+  // --- DATABASE_URL: required in dev/prod; relaxed in test ---
+  // Test mode preserves the v3.0 silent-no-op behavior of `db.ts` so the
+  // pre-existing test suite (which never set DATABASE_URL and passed by
+  // accident — see diagnosis) keeps working until Phase 4 moves it to
+  // testcontainers. Outside `NODE_ENV=test` we fail fast.
+  if (nodeEnv !== "test") {
+    if (env.DATABASE_URL === undefined) {
+      issues.push("DATABASE_URL: DATABASE_URL is required (set in .env).");
+    } else if (env.DATABASE_URL === "") {
+      issues.push("DATABASE_URL: DATABASE_URL must not be empty.");
+    }
+  }
+
+  if (issues.length > 0) {
+    throw new EnvValidationError(issues);
+  }
+
+  return {
+    appId: env.VITE_APP_ID ?? "",
+    cookieSecret: env.JWT_SECRET!,
+    databaseUrl: env.DATABASE_URL ?? "",
+    oAuthServerUrl: env.OAUTH_SERVER_URL ?? "",
+    ownerOpenId: env.OWNER_OPEN_ID ?? "",
+    isProduction: nodeEnv === "production",
+    isTest: nodeEnv === "test",
+    forgeApiUrl: env.BUILT_IN_FORGE_API_URL ?? "",
+    forgeApiKey: env.BUILT_IN_FORGE_API_KEY ?? "",
+  } as const;
+}
+
+export const ENV = loadEnv();

--- a/server/_core/log.test.ts
+++ b/server/_core/log.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { redact } from "./log";
+
+describe("log.redact (issue #11)", () => {
+  it("masks API key fields by exact name", () => {
+    const out = redact({
+      llmApiKey: "sk-or-v1-abcdef123456789",
+      openRouterKey: "sk-or-v1-abcdef123456789",
+      elevenlabsApiKey: "el-1234567890abcdef",
+      whisperApiKey: "wh-shortlived",
+    }) as Record<string, string>;
+    expect(out.llmApiKey).toBe("sk***89");
+    expect(out.openRouterKey).toBe("sk***89");
+    expect(out.elevenlabsApiKey).toBe("el***ef");
+    expect(out.whisperApiKey).toBe("wh***ed");
+  });
+
+  it("masks key-like names by pattern (length-preserving)", () => {
+    const out = redact({
+      somethingApiKey: "secret-value-here",
+      ourSecret: "topsecret",
+      myToken: "abcdef",
+    }) as Record<string, string>;
+    expect(out.somethingApiKey).toMatch(/\*\*\*/);
+    expect(out.somethingApiKey).not.toBe("secret-value-here");
+    expect(out.ourSecret).toBe("to***et");
+    expect(out.myToken).toBe("ab***ef");
+  });
+
+  it("strict-redacts ALWAYS_REDACT_KEYS to '***' (no length leak)", () => {
+    const out = redact({
+      access_token: "bearer-xyz",
+      cookieSecret: "very-long-cookie-secret-value",
+      Authorization: "Bearer eyJ...",
+    }) as Record<string, string>;
+    expect(out.access_token).toBe("***");
+    expect(out.cookieSecret).toBe("***");
+    expect(out.Authorization).toBe("***");
+  });
+
+  it("masks emails", () => {
+    const out = redact({ email: "alice@example.com" }) as Record<string, string>;
+    expect(out.email).toBe("a***@example.com");
+  });
+
+  it("redacts OAuth state and code", () => {
+    const out = redact({
+      state: "eyJyZWRpcmVjdFVyaSI6Ii8ifQ==",
+      code: "auth-code-12345",
+    }) as Record<string, string>;
+    expect(out.state).toBe("***");
+    expect(out.code).toBe("***");
+  });
+
+  it("flattens Error to { name, message } (drops stack)", () => {
+    const e = new Error("Connection failed: sk-abc123");
+    const out = redact(e) as { name: string; message: string; stack?: string };
+    expect(out.name).toBe("Error");
+    expect(out.message).toBe("Connection failed: sk-abc123");
+    expect(out.stack).toBeUndefined();
+  });
+
+  it("handles nested objects", () => {
+    const out = redact({
+      user: { id: 1, email: "x@y.com", apiKey: "sk-deep" },
+      config: { llmApiKey: "sk-config" },
+    }) as any;
+    expect(out.user.id).toBe(1);
+    expect(out.user.email).toBe("x***@y.com");
+    expect(out.user.apiKey).toBe("sk***ep");
+    expect(out.config.llmApiKey).toBe("sk***ig");
+  });
+
+  it("truncates very long strings", () => {
+    const long = "a".repeat(1000);
+    const out = redact(long) as string;
+    expect(out.length).toBeLessThan(1000);
+    expect(out).toMatch(/\[truncated\]$/);
+  });
+
+  it("limits array size", () => {
+    const big = Array.from({ length: 100 }, (_, i) => i);
+    const out = redact(big) as unknown[];
+    // 50 items + 1 marker
+    expect(out.length).toBe(51);
+    expect(out[50]).toBe("...[+50]");
+  });
+
+  it("stops at max depth", () => {
+    let nested: any = "leaf";
+    for (let i = 0; i < 20; i++) nested = { nested };
+    const out = redact(nested);
+    // Should produce a finite string somewhere indicating truncation.
+    expect(JSON.stringify(out)).toContain("max-depth");
+  });
+
+  it("preserves null and undefined", () => {
+    expect(redact(null)).toBe(null);
+    expect(redact(undefined)).toBe(undefined);
+  });
+
+  it("does not mutate the input", () => {
+    const input = { apiKey: "sk-secret", user: { email: "x@y.com" } };
+    redact(input);
+    expect(input.apiKey).toBe("sk-secret");
+    expect(input.user.email).toBe("x@y.com");
+  });
+});

--- a/server/_core/log.ts
+++ b/server/_core/log.ts
@@ -1,0 +1,133 @@
+/**
+ * Log utility with PII / secret redaction (issue #11).
+ *
+ * This is a Phase-1a stop-gap: it wraps `console.{error,warn,log}` and
+ * scrubs known-sensitive keys from any object passed to the call. Phase 5
+ * (issue #31) replaces this with `pino` + a proper redaction pipeline +
+ * request IDs + JSON output.
+ *
+ * Use `log.error / log.warn / log.info` in place of `console.error / warn / log`
+ * anywhere you might log error objects, request bodies, user records, or
+ * results from third-party APIs.
+ */
+
+/** Exact key names that always get masked, regardless of value type. */
+const ALWAYS_REDACT_KEYS = new Set([
+  "password",
+  "passwd",
+  "secret",
+  "cookieSecret",
+  "jwt",
+  "JWT_SECRET",
+  "JWT",
+  "code", // OAuth one-time code
+  "state", // OAuth state
+  "accessToken",
+  "refreshToken",
+  "idToken",
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "Authorization",
+  "authorization",
+  "Cookie",
+  "cookie",
+  "openId",
+]);
+
+/** Pattern match for any field name containing one of these substrings. */
+const KEY_PATTERN = /(key|secret|token|password|credential)/i;
+
+/** Top-level keys whose value should be email-masked. */
+const EMAIL_KEYS = new Set(["email", "Email", "userEmail"]);
+
+const MAX_DEPTH = 5;
+const MAX_ARRAY = 50;
+const MAX_STRING = 500;
+
+function maskShort(): string {
+  return "***";
+}
+
+function maskString(value: string): string {
+  if (value.length <= 4) return maskShort();
+  return `${value.slice(0, 2)}***${value.slice(-2)}`;
+}
+
+function maskEmail(value: string): string {
+  const at = value.indexOf("@");
+  if (at <= 0) return maskString(value);
+  const local = value.slice(0, at);
+  const domain = value.slice(at + 1);
+  // Always reveal the first character of the local part (so operators can
+  // disambiguate users in logs without exposing the full address).
+  const safeLocal = local.slice(0, 1) + "***";
+  return `${safeLocal}@${domain}`;
+}
+
+/**
+ * Recursively redact sensitive fields. Errors are flattened to
+ * `{ name, message }` (stack omitted because it can include source code
+ * snippets containing secrets).
+ */
+export function redact(input: unknown, depth = MAX_DEPTH): unknown {
+  if (depth <= 0) return "[redacted:max-depth]";
+  if (input === null || input === undefined) return input;
+
+  // Primitives.
+  if (typeof input === "string") {
+    return input.length > MAX_STRING
+      ? input.slice(0, MAX_STRING) + "...[truncated]"
+      : input;
+  }
+  if (typeof input === "number" || typeof input === "boolean") return input;
+  if (typeof input === "bigint") return input.toString();
+  if (typeof input === "function" || typeof input === "symbol") return "[fn]";
+
+  // Errors: keep name + message, drop stack and any attached props.
+  if (input instanceof Error) {
+    return { name: input.name, message: input.message };
+  }
+
+  // Arrays.
+  if (Array.isArray(input)) {
+    return input
+      .slice(0, MAX_ARRAY)
+      .map(v => redact(v, depth - 1))
+      .concat(input.length > MAX_ARRAY ? [`...[+${input.length - MAX_ARRAY}]`] : []);
+  }
+
+  // Plain objects.
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    if (ALWAYS_REDACT_KEYS.has(k)) {
+      // Strict redaction for the most sensitive fields — no length leak.
+      out[k] = "***";
+    } else if (KEY_PATTERN.test(k)) {
+      // Pattern-matched fields keep first/last 2 chars so an operator can
+      // tell at a glance whether the value differs across log lines.
+      out[k] = typeof v === "string" ? maskString(v) : "[redacted]";
+    } else if (EMAIL_KEYS.has(k) && typeof v === "string") {
+      out[k] = maskEmail(v);
+    } else {
+      out[k] = redact(v, depth - 1);
+    }
+  }
+  return out;
+}
+
+function format(label: string, args: unknown[]): unknown[] {
+  return [label, ...args.map(a => redact(a))];
+}
+
+export const log = {
+  error: (label: string, ...args: unknown[]): void => {
+    console.error(...format(label, args));
+  },
+  warn: (label: string, ...args: unknown[]): void => {
+    console.warn(...format(label, args));
+  },
+  info: (label: string, ...args: unknown[]): void => {
+    console.log(...format(label, args));
+  },
+};

--- a/server/_core/oauth.ts
+++ b/server/_core/oauth.ts
@@ -2,6 +2,7 @@ import { COOKIE_NAME, ONE_YEAR_MS } from "@shared/const";
 import type { Express, Request, Response } from "express";
 import * as db from "../db";
 import { getSessionCookieOptions } from "./cookies";
+import { log } from "./log";
 import { sdk } from "./sdk";
 
 function getQueryParam(req: Request, key: string): string | undefined {
@@ -46,7 +47,7 @@ export function registerOAuthRoutes(app: Express) {
 
       res.redirect(302, "/");
     } catch (error) {
-      console.error("[OAuth] Callback failed", error);
+      log.error("[OAuth] Callback failed", error);
       res.status(500).json({ error: "OAuth callback failed" });
     }
   });

--- a/server/_core/sdk.ts
+++ b/server/_core/sdk.ts
@@ -7,6 +7,7 @@ import { SignJWT, jwtVerify } from "jose";
 import type { User } from "../../drizzle/schema";
 import * as db from "../db";
 import { ENV } from "./env";
+import { log } from "./log";
 import type {
   ExchangeTokenRequest,
   ExchangeTokenResponse,
@@ -227,7 +228,7 @@ class SDKServer {
         name,
       };
     } catch (error) {
-      console.warn("[Auth] Session verification failed", String(error));
+      log.warn("[Auth] Session verification failed", error);
       return null;
     }
   }
@@ -283,7 +284,7 @@ class SDKServer {
         });
         user = await db.getUserByOpenId(userInfo.openId);
       } catch (error) {
-        console.error("[Auth] Failed to sync user from OAuth:", error);
+        log.error("[Auth] Failed to sync user from OAuth", error);
         throw ForbiddenError("Failed to sync user info");
       }
     }

--- a/server/db.ts
+++ b/server/db.ts
@@ -26,6 +26,7 @@ import {
   type InsertNotification,
 } from "../drizzle/schema";
 import { ENV } from "./_core/env";
+import { log } from "./_core/log";
 
 let _db: ReturnType<typeof drizzle> | null = null;
 
@@ -97,7 +98,7 @@ export async function upsertUser(user: InsertUser): Promise<void> {
       set: updateSet,
     });
   } catch (error) {
-    console.error("[Database] Failed to upsert user:", error);
+    log.error("[Database] Failed to upsert user", error);
     throw error;
   }
 }

--- a/server/ownership.test.ts
+++ b/server/ownership.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { TRPCError } from "@trpc/server";
+import type { User } from "../drizzle/schema";
+
+/**
+ * Regression test for issue #4: ownership-before-write.
+ *
+ * The v3.0 implementations of `chat.sendMessage` and `selfie.generate`
+ * accepted any `conversationId` from the client and only verified
+ * ownership AFTER `createMessage` ran — so an attacker holding a valid
+ * session could insert messages into any user's conversation.
+ *
+ * This test mocks `db.ts` and asserts:
+ *   1. `getConversation` is called with the caller's `userId` BEFORE
+ *      `createMessage` is called (by recording invocation order).
+ *   2. When `getConversation` returns undefined (= conversation not
+ *      owned by the caller), the route throws TRPCError(FORBIDDEN) and
+ *      `createMessage` is never called.
+ *
+ * If a future refactor reintroduces "write first, validate later", these
+ * tests fail.
+ */
+
+vi.mock("../server/db", async () => {
+  return await vi.importActual("./db");
+});
+
+import * as db from "./db";
+import { appRouter } from "./routers";
+
+const fakeUser: User = {
+  id: 42,
+  openId: "test-openid-42",
+  name: "Tester",
+  email: null,
+  loginMethod: null,
+  avatarUrl: null,
+  createdAt: new Date(),
+  lastSignedIn: new Date(),
+  lastActiveAt: new Date(),
+};
+
+const ctx = {
+  user: fakeUser,
+  cookies: {} as any,
+  res: {} as any,
+  req: {} as any,
+};
+
+const callOrder: string[] = [];
+
+beforeEach(() => {
+  callOrder.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe("issue #4: ownership-before-write", () => {
+  describe("chat.sendMessage", () => {
+    it("calls getConversation BEFORE createMessage", async () => {
+      vi.spyOn(db, "getConversation").mockImplementation(async () => {
+        callOrder.push("getConversation");
+        return {
+          id: 1,
+          userId: 42,
+          girlfriendId: 1,
+          title: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as any;
+      });
+      vi.spyOn(db, "createMessage").mockImplementation(async () => {
+        callOrder.push("createMessage");
+        return {} as any;
+      });
+      vi.spyOn(db, "getActiveGirlfriend").mockResolvedValue(null);
+
+      const caller = appRouter.createCaller(ctx as any);
+      try {
+        await caller.chat.sendMessage({
+          conversationId: 1,
+          content: "hi",
+        });
+      } catch {
+        // ignore — we expect a downstream error since girlfriend is null,
+        // but we only care about the order of the first two calls.
+      }
+
+      expect(callOrder[0]).toBe("getConversation");
+      // createMessage must NOT precede getConversation. It is fine for it
+      // to never run (because girlfriend lookup fails first); what would
+      // be a regression is createMessage running BEFORE getConversation.
+      const createIdx = callOrder.indexOf("createMessage");
+      const getIdx = callOrder.indexOf("getConversation");
+      if (createIdx !== -1) {
+        expect(createIdx).toBeGreaterThan(getIdx);
+      }
+    });
+
+    it("throws FORBIDDEN and does NOT write when conversation is not owned", async () => {
+      vi.spyOn(db, "getConversation").mockImplementation(async () => {
+        callOrder.push("getConversation");
+        return undefined; // simulate "not found / not owned"
+      });
+      const createMessageSpy = vi
+        .spyOn(db, "createMessage")
+        .mockImplementation(async () => {
+          callOrder.push("createMessage");
+          return {} as any;
+        });
+
+      const caller = appRouter.createCaller(ctx as any);
+      await expect(
+        caller.chat.sendMessage({ conversationId: 999, content: "hi" })
+      ).rejects.toThrowError(TRPCError);
+
+      expect(createMessageSpy).not.toHaveBeenCalled();
+      expect(callOrder).toEqual(["getConversation"]);
+    });
+  });
+
+  describe("selfie.generate", () => {
+    it("throws FORBIDDEN and does NOT write when conversation is not owned", async () => {
+      vi.spyOn(db, "getConversation").mockImplementation(async () => {
+        callOrder.push("getConversation");
+        return undefined;
+      });
+      const createMessageSpy = vi
+        .spyOn(db, "createMessage")
+        .mockImplementation(async () => {
+          callOrder.push("createMessage");
+          return {} as any;
+        });
+      const createSelfieSpy = vi
+        .spyOn(db, "createSelfie")
+        .mockImplementation(async () => {
+          callOrder.push("createSelfie");
+          return {} as any;
+        });
+
+      const caller = appRouter.createCaller(ctx as any);
+      await expect(
+        caller.selfie.generate({
+          conversationId: 999,
+          userContext: "wearing a dress",
+        })
+      ).rejects.toThrowError(TRPCError);
+
+      expect(createMessageSpy).not.toHaveBeenCalled();
+      expect(createSelfieSpy).not.toHaveBeenCalled();
+      expect(callOrder).toEqual(["getConversation"]);
+    });
+  });
+});

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -395,23 +395,33 @@ export const appRouter = router({
         })
       )
       .mutation(async ({ ctx, input }) => {
-        // 1. 保存用户消息
+        // 1. 验证对话所有权（必须在写入前完成 — 见 issue #4）
+        // 之前的实现顺序是 createMessage → getConversation，这意味着任何登录用户
+        // 传一个别人的 conversationId 也能成功 INSERT 一条 user message 进对方对话。
+        const conversation = await getConversation(input.conversationId, ctx.user.id);
+        if (!conversation) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Conversation not found or not owned by current user",
+          });
+        }
+
+        const girlfriend = await getActiveGirlfriend(ctx.user.id);
+        if (!girlfriend) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "No active girlfriend found",
+          });
+        }
+
+        // 2. 保存用户消息（所有权已校验）
+        // TODO(phase-2 / issue #17): 把 user msg + assistant msg 包进同一个事务，
+        // 避免 LLM 调用失败时留下半截对话。
         const userMessage = await createMessage({
           conversationId: input.conversationId,
           role: "user",
           content: input.content,
         });
-
-        // 2. 获取对话上下文
-        const conversation = await getConversation(input.conversationId, ctx.user.id);
-        if (!conversation) {
-          throw new Error("Conversation not found");
-        }
-
-        const girlfriend = await getActiveGirlfriend(ctx.user.id);
-        if (!girlfriend) {
-          throw new Error("No active girlfriend found");
-        }
 
         // 3. 获取最近的消息历史（用于上下文）
         const recentMessages = await getRecentMessages(input.conversationId, 10);
@@ -524,16 +534,33 @@ ${girlfriend.interests ? `兴趣爱好：\n${girlfriend.interests}` : ""}
         })
       )
       .mutation(async ({ ctx, input }) => {
+        // 0. 验证对话所有权 — 见 issue #4。selfie.generate 此前会无条件
+        // INSERT 一条 assistant message 到 input.conversationId，攻击者可借此
+        // 把"自拍消息"写进任意对话。
+        const conversation = await getConversation(input.conversationId, ctx.user.id);
+        if (!conversation) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Conversation not found or not owned by current user",
+          });
+        }
+
         // 1. 获取女友配置
         const girlfriend = await getActiveGirlfriend(ctx.user.id);
         if (!girlfriend) {
-          throw new Error("No active girlfriend found");
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "No active girlfriend found",
+          });
         }
 
         // 2. 获取 API 配置
         const apiConfig = await getUserApiConfig(ctx.user.id);
         if (!apiConfig?.falApiKey) {
-          throw new Error("fal.ai API key not configured");
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "fal.ai API key not configured",
+          });
         }
 
         // 3. 使用 Clawra 提示词模板生成提示词

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["server/**/*.test.ts", "server/**/*.spec.ts"],
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,21 @@
+/**
+ * Vitest setup file — runs before any test module imports.
+ *
+ * Provides safe defaults for the env vars that `server/_core/env.ts`
+ * insists on at load time, so individual tests don't have to remember
+ * to set them. Tests that need to verify env-validation behavior
+ * (e.g. `server/_core/env.test.ts`) reset modules and override
+ * `process.env` themselves.
+ */
+
+// 64-char placeholder. Tests never sign anything that leaves the process,
+// so this is fine — but anything ≥ 32 chars satisfies the schema.
+process.env.JWT_SECRET ??=
+  "test-jwt-secret-not-used-for-real-signing-padded-padded-padded";
+process.env.NODE_ENV ??= "test";
+
+// Note: DATABASE_URL is intentionally NOT set here. `env.ts` relaxes the
+// DATABASE_URL requirement when NODE_ENV=test, so `db.ts` falls back to its
+// silent-no-op path — the same path the v3.0 test suite was implicitly
+// relying on. Phase 4 will move tests to testcontainers and remove this
+// carve-out (see issue #27).


### PR DESCRIPTION
## Summary

First slice of the Phase 1 security hardening — the **defensive patches**
that don't require architecture changes. Three fixes, three issues
closed, three new test files. **No application behavior change for
correctly-configured deployments.**

| Issue | Severity | Fix | New tests |
| --- | --- | --- | --- |
| [#6](https://github.com/Do-fei/my-raze/issues/6) | critical | `JWT_SECRET` fail-fast at boot (≥32 chars; refuses to start otherwise) | `server/_core/env.test.ts` (9 cases) |
| [#11](https://github.com/Do-fei/my-raze/issues/11) | medium | PII / secret redaction utility + applied to 4 highest-risk log call sites | `server/_core/log.test.ts` (12 cases) |
| [#4](https://github.com/Do-fei/my-raze/issues/4) | critical | Ownership-before-write in `chat.sendMessage` and `selfie.generate` | `server/ownership.test.ts` (3 cases) |

**Phase 1 has 8 issues total**; this PR ships 3. The remaining 5 land in
follow-up PRs:

- `phase-1a-ii` — OAuth state HMAC ([#7](https://github.com/Do-fei/my-raze/issues/7)), CSRF ([#8](https://github.com/Do-fei/my-raze/issues/8)), XSS markdown sanitize ([#9](https://github.com/Do-fei/my-raze/issues/9))
- `phase-1b` — `KeyProvider` abstraction + drop user-key surface area ([#2](https://github.com/Do-fei/my-raze/issues/2), [#3](https://github.com/Do-fei/my-raze/issues/3))
- `phase-1c` — rate limiting + Stripe subscriptions ([#5](https://github.com/Do-fei/my-raze/issues/5), [#10](https://github.com/Do-fei/my-raze/issues/10), [#12](https://github.com/Do-fei/my-raze/issues/12))

Splitting was a deliberate choice for review tractability — see ADR
0002 follow-up note.

## What changes for deployers

- **You must set `JWT_SECRET` to a real ≥32-char value before booting.**
  `.env.example` already documents the `openssl rand -hex 32` recipe.
  An empty / short secret now refuses to start with a clear error.
- **You must set `DATABASE_URL`** (in dev or prod). Tests are exempt
  via a `NODE_ENV=test` carve-out so the v3.0 silent-no-op pattern
  keeps working until Phase 4 moves tests to testcontainers (issue #27).
- Any logs that previously surfaced full error objects from OAuth /
  DB upsert / session-verify failures now mask known-sensitive fields
  (API keys, OAuth state, cookies, Authorization headers, emails).

## What an attacker can no longer do

- Forge a session for any user against a misconfigured deployment that
  forgot to set `JWT_SECRET` (the empty-secret HS256 trivial-forge bug).
- Insert chat messages / selfies into other users' conversations by
  guessing or enumerating `conversationId`.
- Harvest API keys from the operator's stdout log shipper.

## Test results

```
server/_core/env.test.ts        9 pass
server/_core/log.test.ts       12 pass
server/ownership.test.ts        3 pass
                              ----
                               24 new tests, all green
```

Pre-existing failures (31 tests) are unchanged — they require Manus
OAuth + Forge storage credentials this branch deliberately does not
configure (also being cleaned up in Phase 4 / #27).

## Verified locally

- `GET /` → 200, `GET /trpc/auth.me` → 200 throughout the change set
- `tsx watch` reloaded cleanly on every save
- Booting with empty `JWT_SECRET` shows a clean multi-line error and
  exits non-zero (manually checked)

## Test plan

- [ ] Pull branch, `cp .env.example .env`, set `JWT_SECRET` to anything **shorter than 32 chars**, run `pnpm dev` — expect refusal with a readable error pointing to `.env.example`.
- [ ] Set a 64-char `JWT_SECRET`, run `pnpm dev` — boots normally.
- [ ] `pnpm test server/_core/env.test.ts server/_core/log.test.ts server/ownership.test.ts` — 24/24 green.
- [ ] Spot-check a `console.error("...", error)` site no longer leaks raw user / token data into stdout (manual; can be done by triggering an OAuth callback failure with `OAUTH_SERVER_URL` unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)