### PR TITLE
docs(adr): lock in auth (Lucia) + billing (Lemon Squeezy) + pricing decisions

### DIFF
--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -170,10 +170,13 @@ account-deletion request can be self-served end-to-end.
 
 ## ADR index
 
-| ID    | Title                              | Status   |
-| ----- | ---------------------------------- | -------- |
-| 0001  | Toolchain choices for local dev    | Accepted |
-| 0002  | Monetization: subscription + BYOK  | Accepted |
+| ID    | Title                                       | Status   |
+| ----- | ------------------------------------------- | -------- |
+| 0001  | Toolchain choices for local dev             | Accepted |
+| 0002  | Monetization: subscription + BYOK           | Accepted |
+| 0003  | Auth replacement: Lucia v3                  | Accepted |
+| 0004  | Billing platform: Lemon Squeezy             | Accepted |
+| 0005  | Pricing tiers, free-tier limits, refunds    | Accepted |
 
 ---
 

--- a/docs/adr/0003-auth-replacement-lucia.md
+++ b/docs/adr/0003-auth-replacement-lucia.md
@@ -1,0 +1,127 @@
+# ADR 0003 — Auth replacement: Lucia v3
+
+- **Status:** Accepted
+- **Date:** 2026-04-30
+- **Decision-makers:** Project owner
+- **Related:** [ADR 0002](./0002-monetization-model.md), [REFACTORING.md → Phase 1b](../REFACTORING.md)
+- **Implementation:** Phase 1b-ii branch (`phase-1b-ii/auth-replacement`)
+
+## Context
+
+The v3.0 MVP authenticates users through a **Manus-hosted OAuth
+service**: the frontend redirects to `${OAUTH_SERVER_URL}/oauth/...`
+with a base64-encoded state string, the server exchanges the code at
+`/webdev.v1.WebDevAuthPublicService/ExchangeToken`, and the resulting
+session is signed with `JWT_SECRET` and stored in an httpOnly cookie.
+
+This implementation has three blocking problems for our launch goal:
+
+1. **External dependency on Manus.** Self-hosters cannot run the open-
+   source codebase without Manus credentials. Commercial deployments
+   are coupled to a third party we don't control.
+2. **No HMAC on OAuth state** ([issue #7](https://github.com/Do-fei/my-raze/issues/7)).
+   `state = btoa(redirectUri)` carries no integrity check; an attacker
+   can forge any state value, enabling open-redirect / login-CSRF
+   variants. (Issue #7 was deferred from Phase 1a-ii precisely because
+   the right fix is to do it inside the new auth flow.)
+3. **Email and login-method handling is fragile** — the SDK has a
+   custom `deriveLoginMethod` switch that only knows the platforms
+   Manus chooses to advertise. Adding email / passkey / new SSO is
+   blocked on Manus shipping it first.
+
+We need a **self-hostable, standards-compliant** auth path that lives
+entirely inside this codebase and supports email / OAuth / future
+passkey without third-party hops.
+
+## Decision
+
+Adopt **[Lucia v3](https://lucia-auth.com/)** as the auth library.
+
+### What Lucia gives us
+
+- **Session-only library** — no opinions about UI, no opinions about
+  frameworks beyond a small adapter. It manages session creation,
+  validation, invalidation, and rotation. Token formats and storage
+  remain ours to choose.
+- **Adapter for Drizzle + MySQL2** out of the box. Sessions live in a
+  new `sessions` table; the existing `users` table absorbs Lucia's
+  expected fields with no migration drama.
+- **Pluggable identity providers.** v3 ships with first-class support
+  for the OAuth providers we care about (GitHub, Google, Apple,
+  email-magic-link, passkey/WebAuthn). Adding a provider is ~50 lines.
+- **Active maintenance + a community signing on for the long haul.**
+  v3 (the "library" rewrite of v2) explicitly ships smaller and more
+  conservative APIs. Stability is acceptable for a project we expect
+  to maintain for years.
+
+### Sign-in shape we're shipping in Phase 1b-ii
+
+Two methods on day one. More can be added incrementally without
+schema work.
+
+1. **Email + magic-link** as the primary self-hostable path. No
+   passwords. Lucia provides the session primitives; we send a one-
+   time-use signed link via email (Resend by default; SMTP env vars
+   for self-hosters who prefer their own).
+2. **GitHub OAuth** as the developer-friendly secondary, mostly for
+   the open-source crowd that already has a GitHub account.
+
+Phase 1b-ii's PR will land both. Future ADRs cover Google / Apple /
+passkey when we make those decisions.
+
+### State integrity (closes issue #7)
+
+Lucia's recommended OAuth flow generates a **CSRF-bound, HMAC-signed
+state token** automatically and verifies it on callback. Our state-
+forging vector simply doesn't exist in the new flow — there's nothing
+to retrofit. Issue #7 closes when this PR ships.
+
+### Migration strategy (one-shot, not gradual)
+
+- The Manus-OAuth code path is **deleted**, not deprecated. The repo
+  is in `DO NOT DEPLOY` status (per the README banner) so we don't
+  need a graceful migration window for live users.
+- A drizzle migration adds the `sessions` table and the columns Lucia
+  needs on `users` (e.g. `hashedPassword` is not added — we're
+  password-less; `email` already exists).
+- Existing users in the local dev DB are kept (their `openId` becomes
+  legacy and unused). On first login they get a fresh Lucia session.
+
+## Why Lucia over the alternatives
+
+| Option | Why we picked / didn't pick |
+| --- | --- |
+| **Lucia v3** ✅ | Library, not framework. We own the surface. Drizzle + MySQL adapter ready. Active maintenance. Direct support for email-magic-link + GitHub OAuth in Phase 1b-ii. |
+| Better-Auth | Newer, faster-moving, nicer DX. Still in pre-1.0 churn. Picking it means absorbing breaking changes into a security-critical path. Reconsider in 6 months. |
+| Self-rolled email-magic-link | Minimum dependencies but maximum surface area to test (token generation, replay protection, rate-limiting, session rotation). We don't get to be sloppy on auth code, and Lucia already got it right. |
+| Keep Manus OAuth + add HMAC | Doesn't address (1) the dependency or (3) the inflexibility. Pure rework. |
+| Auth0 / Clerk / Supabase Auth | Hosted services. Solve the wrong problem (we want self-hostable). The "free tier" trap is real. |
+| Lucia v2 | Superseded by v3. Don't start on a deprecated major version. |
+
+## Consequences
+
+- **No more `OAUTH_SERVER_URL` / `OWNER_OPEN_ID` / `VITE_APP_ID` env
+  vars after Phase 1b-ii lands.** The `.env.example` schema gets
+  cleaner (issue follow-up).
+- **`server/_core/sdk.ts` (the Manus SDK wrapper) is deleted.** All
+  the `axios.post` calls to `webdev.v1.WebDevAuthPublicService` go
+  away. This shrinks the surface of "as any" casts the diagnosis
+  flagged.
+- **The `users.openId` unique-key column becomes legacy.** We don't
+  drop it (might be useful for analytics) but no new code reads it.
+  Future ADR may rename it.
+- **Cookie + CSRF code from Phase 1a is reused unchanged.** Lucia is
+  fine with httpOnly cookies + double-submit token; we keep that
+  layer of the stack as-is.
+- **A new env var `EMAIL_PROVIDER_API_KEY` (Resend) is required for
+  magic-link sending in non-test environments.** Self-hosters can set
+  `EMAIL_PROVIDER=smtp` + `SMTP_HOST/USER/PASS` for their own server.
+- **Issue #7 closes.** The OAuth-state HMAC is part of Lucia's
+  built-in flow rather than a retrofit.
+
+## References
+
+- Lucia v3 docs: https://lucia-auth.com/
+- Drizzle adapter: https://github.com/lucia-auth/lucia/tree/main/packages/adapter-drizzle
+- Magic-link pattern reference: https://lucia-auth.com/guides/email-and-password
+  (we adapt this for password-less by skipping the password column)

--- a/docs/adr/0004-billing-lemonsqueezy.md
+++ b/docs/adr/0004-billing-lemonsqueezy.md
@@ -1,0 +1,124 @@
+# ADR 0004 — Billing platform: Lemon Squeezy (Merchant of Record)
+
+- **Status:** Accepted
+- **Date:** 2026-04-30
+- **Decision-makers:** Project owner
+- **Related:** [ADR 0002](./0002-monetization-model.md), [ADR 0005](./0005-pricing-and-tiers.md)
+- **Implementation:** Phase 1c branch (`phase-1c/subscriptions`)
+
+## Context
+
+ADR 0002 committed to a subscription model with three tiers (free /
+plus / pro). ADR 0005 froze the placeholder prices. We still needed
+to choose **which billing platform** ingests the money.
+
+Three options were on the table. The decision needs to balance:
+
+- **Tax compliance.** Selling subscriptions internationally means VAT
+  in the EU, GST in AU, sales tax in many US states, etc. Doing this
+  ourselves is a multi-week project of its own.
+- **Geographic acceptance.** my-raze targets a global audience
+  including Mainland China, where Visa/Mastercard penetration is low
+  and Stripe support is limited.
+- **Webhook reliability and DX.** Phase 1c subscription-state
+  reconciliation depends on webhooks. A platform with bad webhook
+  semantics costs us reliability.
+- **Open-source compatibility.** A self-host option without billing
+  must remain workable.
+
+## Decision
+
+**Adopt [Lemon Squeezy](https://lemonsqueezy.com/) as the billing
+platform.**
+
+### What Lemon Squeezy gives us
+
+- **Merchant of Record (MoR) model.** Lemon Squeezy is the seller of
+  record. They handle international VAT/GST/sales-tax collection,
+  filing, and remittance. We handle the product. This is the single
+  highest-leverage reason for the choice.
+- **CN-friendly card acceptance.** Critically more permissive than
+  Stripe's default for Chinese-issued cards. Not 100% (cross-border
+  card processing in CN is what it is), but materially better than
+  Stripe baseline.
+- **Native subscription primitives** with the policies ADR 0005
+  committed to: pro-ration on upgrade, end-of-cycle on downgrade,
+  cancellation that retains service until period end, full refunds
+  within configurable window.
+- **First-class webhooks** for the subscription lifecycle:
+  `subscription_created`, `subscription_updated`,
+  `subscription_payment_success`, `subscription_payment_failed`,
+  `subscription_cancelled`, `subscription_expired`,
+  `subscription_resumed`. These map cleanly to a `subscriptions` table
+  state machine.
+- **Per-plan custom variant fields** to encode our quota policy
+  (chats/day, images/month) so it lives next to the plan rather than
+  hard-coded in app code — future plan tweaks don't require a deploy.
+- **Test mode** with full webhook simulation before going live.
+
+### Implementation shape (Phase 1c outline)
+
+- New `subscriptions` table:
+  `(userId, lemonSubscriptionId, status, plan, periodStart, periodEnd,
+   cancelAt, createdAt, updatedAt)`.
+- New `usage_meters` table with composite PK `(userId, month, meter)`
+  where `meter ∈ {chat, image, tts, stt}`.
+- A single webhook endpoint `/api/billing/lemon-webhook` validates
+  the X-Signature header, dispatches by event type, updates the
+  `subscriptions` row, and refills the `usage_meters` on renewal.
+- Quota gating in `chat.sendMessage` etc. consults the active
+  subscription, decrements the meter, returns HTTP 402 when zeroed.
+- BYOK users (per ADR 0002) bypass meters entirely — quota is only
+  applied to operator-key traffic.
+
+### Self-host without billing
+
+The repo will detect `BILLING_PROVIDER` env var:
+
+- `BILLING_PROVIDER=lemonsqueezy` → full subscription flow active
+- `BILLING_PROVIDER=none` → all users behave as the highest tier
+  (functional but the operator pays for everything); the subscription
+  UI is hidden
+
+This makes Lemon Squeezy a concern only for the commercial deployment.
+Self-hosters with their own keys (`OPERATOR_*_KEY` env vars) plus
+`BILLING_PROVIDER=none` get the whole product on day one without
+touching billing code paths.
+
+## Why Lemon Squeezy over the alternatives
+
+| Option | Why we picked / didn't pick |
+| --- | --- |
+| **Lemon Squeezy** ✅ | MoR (zero tax-compliance work), better CN card acceptance than Stripe, mature subscription primitives, clean webhooks, no developer-hostile pricing tiers. |
+| Stripe | Industry default but **not MoR by default** (Stripe Tax helps but is a separate product); CN card acceptance lags badly. We'd absorb tax compliance ourselves which is a multi-week tax-and-legal sidetrack. |
+| Stripe + Tax + custom rules | Solves taxes but doesn't solve CN cards. Cumulative complexity is high. |
+| Paddle | Also MoR, comparable shape to Lemon Squeezy. Lemon Squeezy DX (docs, dashboard, webhook semantics) is materially better in our team's experience. Reconsider if Lemon Squeezy ever raises fees beyond ~5%. |
+| Gumroad | MoR but built around one-shot products; subscriptions are a second-class feature with weaker primitives. Not the right shape. |
+| Self-host (e.g., billingbot, Polar) | Returns us to tax-compliance-as-our-problem. Lemon Squeezy's headline fee (~5% + 50¢) is cheap relative to a tax accountant. |
+| Multiple providers (Stripe + Alipay) | The matrix of "which provider sees which user" makes the codebase non-trivial without product-led signal. Defer until we have signups by region. |
+
+## Consequences
+
+- **No tax-compliance code in the codebase.** Lemon Squeezy handles
+  it; we focus on product.
+- **Webhook integration is the critical-path of Phase 1c.** Plan two
+  full days of webhook reliability work (signature validation, idem-
+  potency, replay protection, dead-letter for failures).
+- **Lemon Squeezy fees (~5% + 50¢/transaction)** become a fixed line
+  item in the unit economics. ADR 0005's pricing math has implicit
+  headroom for this.
+- **CN payment acceptance is "better than Stripe", not "perfect".**
+  Phase 1c+ may add Alipay/WeChat Pay via a separate provider for the
+  CN-mainland user segment. Out of scope for the initial launch.
+- **We are coupled to Lemon Squeezy's continued operation.** If they
+  raise fees, change MoR terms, or shut down, we migrate to Paddle
+  (compatible MoR shape). The `subscriptions` table abstraction is
+  designed to hide the provider from the rest of the app, so a
+  migration is webhook code only.
+
+## References
+
+- Lemon Squeezy webhooks: https://docs.lemonsqueezy.com/help/webhooks
+- Subscription lifecycle: https://docs.lemonsqueezy.com/help/subscriptions/subscription-statuses
+- Refunds API: https://docs.lemonsqueezy.com/api/refunds
+- MoR explainer: https://www.lemonsqueezy.com/blog/merchant-of-record

--- a/docs/adr/0005-pricing-and-tiers.md
+++ b/docs/adr/0005-pricing-and-tiers.md
@@ -1,0 +1,135 @@
+# ADR 0005 — Pricing tiers, free-tier limits, and refund policy
+
+- **Status:** Accepted
+- **Date:** 2026-04-30
+- **Decision-makers:** Project owner
+- **Related:** [ADR 0002](./0002-monetization-model.md) (subscription + BYOK)
+
+## Context
+
+ADR 0002 left three billing-product questions explicitly open:
+
+1. How to price tiers? (Likely token-budget × markup, but needs a survey
+   of actual MVP usage from existing data.)
+2. Do we offer a free tier and what is it capped at?
+3. Refund / unused-quota policy.
+
+These answers don't block the **architecture** of Phase 1b
+(`KeyProvider` + subscription tables) — that work proceeds with these
+values as parameters. But locking the answers in now prevents
+second-guessing during Phase 1c implementation, when we wire Lemon
+Squeezy webhooks and the quota-meter UI.
+
+## Decision
+
+### 1. Pricing — placeholder triple, real research deferred to Phase 1c kickoff
+
+Until we have meaningful billable-user telemetry, formal pricing
+research has too thin a base. Use a **competitor-median placeholder
+triple** for Phase 1c implementation; revisit ~1 week before launch
+with the (by then) real spend data.
+
+| Tier | Price | Anchor |
+| --- | --- | --- |
+| **Free** | $0 | onboarding / proof-of-value |
+| **Plus** | **$9.99 / month** | Character.ai+ ($9.99), Crushon.ai Plus ($9.99) |
+| **Pro** | **$19.99 / month** | Replika Pro ($19.99), Crushon.ai Pro ($19.99) |
+
+These are **placeholder values** — they go into Stripe/Lemon Squeezy
+products but the final numbers are confirmed in Phase 1c kickoff after
+a short structured pricing pass (cost-per-active-user × target margin
+× competitor band).
+
+### 2. Free tier limits
+
+The earlier informal proposal of "5 messages/day per girlfriend, no
+images" was reconsidered and rejected: 5 messages is below the
+threshold where a user can experience the product's core loop, so
+they'd churn before the value showed. Replaced with a **broader free
+tier** that lets users feel the full experience while keeping per-user
+cost trivial.
+
+| Capability | Free | Plus | Pro |
+| --- | --- | --- | --- |
+| LLM model | gpt-4o-mini (locked) | mainstream models, user-selectable | full catalog incl. Claude Opus |
+| Daily chat messages (total) | **30** | 500 | unlimited |
+| Selfie image generation | **1 / day** | 30 / month | 100 / month |
+| TTS / voice playback | ❌ | ElevenLabs ✅ | ElevenLabs + Fish Audio ✅ |
+| Voice transcription (Whisper) | ❌ | ✅ | ✅ |
+| Number of girlfriends | **1** | 3 | unlimited |
+| BYOK (own provider keys) | ✅ — bypasses all quotas | ✅ | ✅ |
+| Soft-delete trash window | 7 days | 7 days | 30 days |
+| Customer support | community / docs | email | priority email |
+
+**Cost reasoning for the free tier**
+
+- gpt-4o-mini: ~$0.0001–$0.001 per message at typical lengths.
+  30 messages/day ≈ **$0.06/active-day** ≈ ~$1.80/month per active
+  free user.
+- Image generation: 1/day on a cheap fal.ai model ≈ $0.01–$0.03/day.
+- Combined: ≤ ~$3/month/active-free-user — sustainable as a paid-user
+  acquisition expense.
+
+**Why we keep BYOK quota-free across all tiers**
+
+- Self-hosters running the open-source code shouldn't have artificial
+  caps imposed by a license.
+- Power users who want models the operator hasn't whitelisted have a
+  legitimate path that doesn't cost the operator anything.
+- "We never see your prompts" is a credible privacy claim only if BYOK
+  bypasses quota — i.e. the operator never has to count tokens against
+  a limit and therefore never has to read the requests.
+
+### 3. Refund and unused-quota policy
+
+Adopt **industry-standard practices verbatim** rather than invent.
+All of the below are natively supported by Lemon Squeezy:
+
+| Policy | Setting |
+| --- | --- |
+| Unused quota | **Does NOT roll over** — resets at each billing cycle (industry standard for SaaS subscriptions) |
+| Full-refund window | **7 days from purchase**, no questions asked |
+| Refund after 7 days | Pro-rated for the unused portion of the current billing cycle |
+| Mid-cycle upgrade | Effective immediately; charged the pro-rated difference |
+| Mid-cycle downgrade | Takes effect at the end of the current billing cycle; user retains higher tier until then |
+| Cancellation | Subscription ends at the conclusion of the current billing cycle; service continues until then |
+| Quota exhaustion (free + paid) | HTTP 402; UI shows upsell + "next reset in N days" |
+| Soft-quota warning threshold | At 80% of the monthly limit |
+
+These get codified in the Terms of Service draft when we launch the
+subscription portal in Phase 1c.
+
+## Consequences
+
+- Phase 1c can hard-code the three tiers + free-tier limits as
+  configuration constants without scope creep.
+- The free-tier cost ceiling (~$3/month/active-free-user) is the lower
+  bound on the **conversion-or-churn** decision: we can absorb a 30:1
+  free-to-paid ratio at $9.99 Plus and still be cash-flow positive on
+  AI cost alone (operator margin is everything else).
+- BYOK staying quota-free creates a **two-population product**: a
+  managed subscription for normies, a self-host/BYOK path for technical
+  users. The same codebase serves both with a single feature flag; the
+  consequences are mostly UI ("subscribe" CTAs hide for BYOK users on
+  every keyclass).
+- The "5 messages/day" rejection means daily AI-cost variance is higher
+  than originally modeled — but at gpt-4o-mini prices the variance is
+  rounding-error.
+
+## Open items (out of scope for this ADR)
+
+- Annual subscription discount (typically 15–20% in the SaaS market) —
+  decided at Phase 1c launch readiness.
+- Family-plan or multi-seat licensing — out of scope until product-led
+  signal demands it.
+- Promotional / referral credits — same.
+- Localized pricing (esp. CN / KR / JP) — Lemon Squeezy supports it
+  natively; deferred until we have signups by region.
+
+## References
+
+- [ADR 0002 — Monetization model](./0002-monetization-model.md)
+- Lemon Squeezy refunds & cancellation: https://docs.lemonsqueezy.com/help/refunds/
+- Pricing-research approach (deferred to Phase 1c): cost-per-active-user
+  × target margin × competitor band, validated against early signup
+  willingness-to-pay survey.


### PR DESCRIPTION
## Summary

Three short ADRs that lock in product-direction decisions made over
the past two days. Pure documentation — no code changes.

| ADR | Title | What it freezes |
| --- | --- | --- |
| **0003** | Auth replacement: Lucia v3 | Drops Manus OAuth in Phase 1b-ii; ships email-magic-link + GitHub OAuth; closes #7 natively (no retrofit). |
| **0004** | Billing platform: Lemon Squeezy | Merchant-of-Record wins on CN card acceptance + tax compliance. `BILLING_PROVIDER=none` keeps self-hosters happy. |
| **0005** | Pricing tiers, free-tier limits, refunds | Placeholder $0 / $9.99 / $19.99. Free tier: 30 chats/day, 1 image/day, 1 girlfriend, no TTS — but **BYOK bypasses all quotas**. Refunds = Lemon Squeezy defaults. |

## Why now (before Phase 1c implementation)

Once Phase 1b-i (#44) merges, Phase 1b-ii (auth replacement) starts.
That work needs to know the auth library choice. Phase 1c (billing)
needs the billing platform, the tier shape, and the free-tier
constants. These ADRs answer all of those questions in one place so
no decision drifts during implementation.

ADRs are immutable once accepted (per `docs/REFACTORING.md`'s process
section), so capturing decisions when they're freshly made is the
whole point.

## Specifically what's in scope vs. deferred

**Decided here:**
- Lucia v3 over Better-Auth / self-rolled / hosted services
- Email-magic-link + GitHub OAuth as the day-one identity providers
- Lemon Squeezy over Stripe / Paddle / Gumroad / self-host
- $0 / $9.99 / $19.99 placeholder tiers
- Free-tier capabilities matrix (gpt-4o-mini, 30 chats/day, 1 image/day,
  1 girlfriend, no TTS, BYOK exempt from quota)
- Industry-standard refund / unused-quota / upgrade-downgrade policy

**Explicitly deferred (out of scope for these ADRs):**
- Annual subscription discount (Phase 1c launch readiness)
- Google / Apple / passkey OAuth providers (incremental, post-launch)
- Alipay / WeChat Pay for CN-mainland (post-launch product-led signal)
- Localized pricing per region
- Final pricing research with real billable-user data
  (Phase 1c kickoff, ~1 week before launch)

## Files

```
docs/adr/0003-auth-replacement-lucia.md       (new)
docs/adr/0004-billing-lemonsqueezy.md         (new)
docs/adr/0005-pricing-and-tiers.md            (new)
docs/REFACTORING.md                            (updated ADR index)
```

## Open questions for the reviewer

These ADRs encode the owner's stated intent verbatim, but if any of
the **rationale** language reads as wrong (e.g., a "why we picked"
table entry sounds off), now is the time to fix it — once accepted
the wording is locked. After merge, edits become "supersede with a
new ADR" rather than "edit in place."

## Test plan

- [ ] Read ADR 0003. The "Why Lucia over the alternatives" table
      captures the comparison the way you'd describe it.
- [ ] Read ADR 0004. The Lemon Squeezy choice is recorded with the
      specific reasoning we discussed (MoR + CN acceptance, not just
      "we like the brand").
- [ ] Read ADR 0005. Pricing triple, free-tier matrix, and refund
      policy match what you signed off on this morning.
- [ ] Spot-check `docs/REFACTORING.md` ADR index — three new rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)